### PR TITLE
add a setting to enable/disable telemetry

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -91,7 +91,7 @@ If necessary, you can update some settings for the extension.
 
 1. The Telemetry can be disabled by unchecking the `qiskitCodeAssistant.enableTelemetry` setting or turning `off` the `telemetry.telemetryLevel` setting:
 
-   > **NOTE**: Your code and the suggested code completions are not collected. What is collected is whether a code suggestion was accepted or dismissed.
+   > **NOTE**: The telemetry does not collect your code nor the suggested code completions. What is collected is whether a code suggestion was accepted or dismissed.
 
 ## Troubleshooting
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -89,7 +89,9 @@ If necessary, you can update some settings for the extension.
 
 1. Keyboard shortcuts can be changed by searching for `qiskit-vscode` in the Keyboard Shortcuts settings
 
-1. Telemetry can be disabled by unchecking the `qiskitCodeAssistant.enableTelemetry` setting or turning `off` the `telemetry.telemetryLevel` setting
+1. The Telemetry can be disabled by unchecking the `qiskitCodeAssistant.enableTelemetry` setting or turning `off` the `telemetry.telemetryLevel` setting:
+
+   > **NOTE**: Your code and the suggested code completions are not collected. What is collected is whether a code suggestion was accepted or dismissed.
 
 ## Troubleshooting
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -89,6 +89,8 @@ If necessary, you can update some settings for the extension.
 
 1. Keyboard shortcuts can be changed by searching for `qiskit-vscode` in the Keyboard Shortcuts settings
 
+1. Telemetry can be disabled by unchecking the `qiskitCodeAssistant.enableTelemetry` setting or turning `off` the `telemetry.telemetryLevel` setting
+
 ## Troubleshooting
 
 If you are not seeing the extension status bar in Visual Studio Code, check the extension is installed and enabled under the Extensions tab.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Customize keyboard shortcuts in VS Code using the `Keyboard Shortcuts` editor. T
 | `qiskit-vscode.accept-suggestion` | `Tab` | Accept the model-generated suggestion |
 | `qiskit-vscode.handle-get-completion` | `Ctrl+.`                | Generate suggestions |
 
+## Telemetry
+
+The Telemetry can be disabled by unchecking the `qiskitCodeAssistant.enableTelemetry` setting or turning `off` the `telemetry.telemetryLevel` setting:
+
+   > **NOTE**: The telemetry does not collect your code nor the suggested code completions. What is collected is whether a code suggestion was accepted or dismissed.
+
 ## Terms of use
 
 * [End User License Agreement (EULA)](https://github.com/Qiskit/qiskit-code-assistant-vscode/blob/main/docs/EULA.md) acceptance required before starting to use the model

--- a/package.json
+++ b/package.json
@@ -79,12 +79,17 @@
           "type": "string",
           "default": "https://qiskit-code-assistant.quantum.ibm.com",
           "format": "url",
-          "description": "URL to the Qiskit Code Assistant Service API"
+          "description": "URL to the Qiskit Code Assistant Service API",
+          "tags": ["usesOnlineServices"]
         },
         "qiskitCodeAssistant.enableTelemetry": {
           "type": "boolean",
           "default": true,
-          "markdownDescription": "Controls whether telemetry is collected. Setting `telemetry.telemetryLevel` to `off` will take precedence."
+          "markdownDescription": "Controls whether telemetry is collected. Setting `telemetry.telemetryLevel` to `off` will take precedence.",
+          "tags": [
+            "telemetry",
+            "usesOnlineServices"
+          ]
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -80,6 +80,11 @@
           "default": "https://qiskit-code-assistant.quantum.ibm.com",
           "format": "url",
           "description": "URL to the Qiskit Code Assistant Service API"
+        },
+        "qiskitCodeAssistant.enableTelemetry": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Controls whether telemetry is collected. Setting `telemetry.telemetryLevel` to `off` will take precedence."
         }
       }
     },

--- a/src/services/codeAssistant.ts
+++ b/src/services/codeAssistant.ts
@@ -184,7 +184,18 @@ export async function postModelPrompt(
 export async function postPromptAcceptance(
   promptId: string,
   accepted: boolean
-): Promise<ResponseMessage> {
+): Promise<ResponseMessage|void> {
+  if (!vscode.env.isTelemetryEnabled) {
+    // VSCode telemetry level is set to `off`
+    return;
+  }
+
+  const telemetryEnabled = config.get<boolean>("enableTelemetry") as boolean;
+  if (!telemetryEnabled) {
+    // Qiskit Code Assistant telemetry is disabled
+    return;
+  }
+  
   // POST /prompt/{promptId}/acceptance
   const endpoint = `${getServiceBaseUrl()}/prompt/${promptId}/acceptance`;
   const apiToken = await getApiToken()


### PR DESCRIPTION
# Description

this PR adds a new `qiskitCodeAssistant.enableTelemetry` setting to enable/disable whether telemetry is collected for the extension. 

## Linked Issue(s)

Fixes #98 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

manually tested the setting on and off and confirmed whether data was sent to and collected by the server.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
