### PR TITLE
Enable the use of IBM Quantum platform (cloud) tokens for login

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -26,11 +26,11 @@ To remove the extension
 
 ### IBM Quantum API Token
 
-To make calls to the service API the extension requires an IBM Quantum API token.
+To make calls to the service API the extension requires an IBM Quantum Cloud API token.
 
 #### Getting your API token
 
-1. Open the [IBM Quantum website](https://quantum.ibm.com/) in your browser
+1. Open the [IBM Quantum website](https://quantum.cloud.ibm.com/) in your browser
 1. Login with your IBM Quantum account
 1. Copy the API token displayed on the upper right side of the webpage (after logging in)
 
@@ -60,11 +60,11 @@ If the spinning icon disappears and the status bar remains with the "No Model Se
 
 ### Accepting the model disclaimer
 
-By default, the extension will use the `granite-8b-qiskit` model. It will appear in the Model Picker in the bottom status bar.
+By default, the extension will use the `granite-3.3-8b-qiskit` model. It will appear in the Model Picker in the bottom status bar.
 
 ![selected model](docs/images/Selected_Model.png)
 
-The first time you use the `granite-8b-qiskit` model a model info view will open and explain a little about the model with links to documentation and the model's license. It will also list some major restrictions that you should be aware of when using the model. Clicking `Accept` will accept the model disclaimer and enable the model for code generation.
+The first time you use the `granite-3.3-8b-qiskit` model a model info view will open and explain a little about the model with links to documentation and the model's license. It will also list some major restrictions that you should be aware of when using the model. Clicking `Accept` will accept the model disclaimer and enable the model for code generation.
 
 ![model disclaimer](docs/images/Model_Disclaimer.png)
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Increase quantum computing developer productivity and learn best practices for Q
 
 **************
 
-Make programming quantum computers even easier with Qiskit Code Assistant, a generative AI code assistant powered by IBM **watson<span style="color:blue;">x</span>**. Trained with approximately 370 million text tokens from Qiskit SDK v1.x, years of Qiskit code examples, and IBM Quantum features, Qiskit Code Assistant accelerates your quantum development workflow by offering LLM-generated suggestions based on [IBM Granite 8B Code](https://www.ibm.com/products/watsonx-ai/foundation-models) that incorporate the latest features and functionalities from IBM. And soon, Qiskit Code Assistant will be able to be used alongside Qiskit patterns building blocks for reusable code and workflow simplification.
+Make programming quantum computers even easier with Qiskit Code Assistant, a generative AI code assistant powered by IBM **watson<span style="color:blue;">x</span>**. Trained with approximately 370 million text tokens from Qiskit SDK v1.x, years of Qiskit code examples, and IBM Quantum features, Qiskit Code Assistant accelerates your quantum development workflow by offering LLM-generated suggestions based on [IBM Granite 3.3 8B](https://www.ibm.com/products/watsonx-ai/foundation-models) that incorporate the latest features and functionalities from IBM. And soon, Qiskit Code Assistant will be able to be used alongside Qiskit patterns building blocks for reusable code and workflow simplification.
 
 Qiskit is the open-source quantum SDK preferred by 69% of respondents to the Unitary Fund's Open Source Software Survey, with nearly 600,000 registered users to date. Now you can get the performance and stability of the Qiskit SDK with the added efficiency of Qiskit Code Assistant to streamline your workflow and optimize your quantum computing programs.
 
 ## Features
 
-* Accelerate Qiskit code generation by leveraging generative AI based on the `granite-8b-qiskit` model
+* Accelerate Qiskit code generation by leveraging generative AI based on the `granite-3.3-8b-qiskit` model
 * Use abstract and specific prompts to generate recommendations
 * Manage code changes by reviewing, accepting, and rejecting suggestions
 * Supports Python code files
@@ -41,9 +41,9 @@ Use `Ctrl+.` with code to obtain specific model-generated suggestions for code c
 
 ## Get started
 
-### Obtain your IBM Quantum Platform API token
+### Obtain your IBM Quantum Cloud Platform API token
 
-Open the [IBM Quantum Platform](https://quantum.ibm.com/) in your browser and log in with your IBM Quantum account. After logging in, an IBM Quantum API token is displayed on the upper right side of the web page.
+Open the [IBM Quantum Platform](https://quantum.cloud.ibm.com/) in your browser and log in with your IBM Quantum account. After logging in, an IBM Quantum API token is displayed on the upper right side of the web page.
 
 ### Set the API token in VS Code
 
@@ -55,9 +55,9 @@ Paste your IBM Quantum API token in the pop-up dialog and press `Enter`.
 
 ### Accept the model disclaimer/EULA
 
-By default, the model you will use is `granite-8b-qiskit`. It will appear in the Model Picker in the bottom of the status bar.
+By default, the model you will use is `granite-3.3-8b-qiskit`. It will appear in the Model Picker in the bottom of the status bar.
 
-The first time you use the `granite-8b-qiskit` model, a model disclaimer/EULA will appear with information about the model and links to documentation and the model's license. It will also list some restrictions that you should be aware of when using the model, including a restriction against using proprietary code. Clicking `Accept` will enable the new model during code generation.
+The first time you use the `granite-3.3-8b-qiskit` model, a model disclaimer/EULA will appear with information about the model and links to documentation and the model's license. It will also list some restrictions that you should be aware of when using the model, including a restriction against using proprietary code. Clicking `Accept` will enable the new model during code generation.
 
 ### Generate code suggestions
 

--- a/src/commands/setApiToken.ts
+++ b/src/commands/setApiToken.ts
@@ -18,7 +18,7 @@ async function getTokenFromJson(): Promise<string | undefined> {
   if (data) {
     try {
       const accounts = JSON.parse(data.toString("utf8")) as QiskitAccountJson;
-      return accounts["qiskit-code-assistant"]?.token || accounts["default-ibm-quantum"]?.token;
+      return accounts["qiskit-code-assistant"]?.token || accounts["default-ibm-quantum-platform"]?.token || accounts["default-ibm-quantum"]?.token;
     } catch(err) {
       console.log(`Unable to parse saved Qiskit account: ${err}`);
     }
@@ -40,7 +40,7 @@ export async function initApiToken(context: ExtensionContext | null): Promise<st
 async function handler(): Promise<void> {
   const context = getExtensionContext();
   const input = await vscode.window.showInputBox({
-    prompt: "Please enter your API token (find yours at quantum.ibm.com):",
+    prompt: "Please enter your API token (find yours at quantum.cloud.ibm.com):",
     placeHolder: "Your token goes here ..."
   });
   if (input !== undefined) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -97,6 +97,9 @@ interface QiskitAccountJson {
   "qiskit-code-assistant"?: {
     token?: string
   },
+  "default-ibm-quantum-platform"?: {
+    token?: string
+  },
   "default-ibm-quantum"?: {
     token?: string
   }


### PR DESCRIPTION
# Description


This PR enables the extension to use the tokens located in the `default-ibm-quantum-platform` section of the `~/.qiskit/qiskit-ibm.json` file for authentication with the tokens from the new IBM Quantum cloud platform. As of today, the tokens from that new platform  (https://quantum.cloud.ibm.com) and the classic one (https://quantum.ibm.com) can be used, but after July 1st, the tokens from the classic one will not be useful. 

## Linked Issue(s)

Fixes #110 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Local testing with the VSIX file including the changes installed

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
